### PR TITLE
css modules to prod config add

### DIFF
--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -81,7 +81,7 @@ module.exports = {
             test: /\.scss$/,
             // we extract the styles into their own .css file instead of having
             // them inside the js.
-            loader: ExtractTextPlugin.extract('style', 'css!postcss!sass')
+            loader: ExtractTextPlugin.extract('style', 'style!css?modules&localIdentName=[name]---[local]---[hash:base64:5]!sass')
         }, {
             test: /\.woff(2)?(\?[a-z0-9#=&.]+)?$/,
             loader: 'url?limit=10000&mimetype=application/font-woff'


### PR DESCRIPTION
I think, you just forgot to add css modules compile to  production config. Fixed.