### PR TITLE
IE11 Support

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill';
 import React from 'react';
 import { render } from 'react-dom';
 import { browserHistory } from 'react-router';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 module.exports = {
     devtool: 'eval-source-map',
     entry: [
+        'babel-polyfill',
         'webpack-dev-server/client?http://localhost:3000',
         'webpack/hot/only-dev-server',
         'react-hot-loader/patch',

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -9,6 +9,8 @@ var StatsPlugin = require('stats-webpack-plugin');
 module.exports = {
     // The entry file. All your app roots fromn here.
     entry: [
+        // Polyfills go here too, like babel-polyfill or whatwg-fetch
+        'babel-polyfill',
         path.join(__dirname, 'app/index.js')
     ],
     // Where you want the output to go

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -7,7 +7,7 @@ var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var StatsPlugin = require('stats-webpack-plugin');
 
 module.exports = {
-    // The entry file. All your app roots fromn here.
+    // The entry file. All your app roots from here.
     entry: [
         // Polyfills go here too, like babel-polyfill or whatwg-fetch
         'babel-polyfill',


### PR DESCRIPTION
This example currently doesn't render in IE11. An exception occurs like:
```
Objects are not valid as a React child (found: object with keys {$$typeof, type, key, ref, props, _owner}).
```

This fixes the issue as per the recommendation here: https://github.com/facebook/react/issues/8379#issuecomment-264934168

Many thanks for the repo!